### PR TITLE
Missing return statement

### DIFF
--- a/core/variant.cpp
+++ b/core/variant.cpp
@@ -532,7 +532,7 @@ bool Variant::is_zero() const {
 		} break;
 		case QUAT: {
 
-			*reinterpret_cast<const Quat*>(_data._mem)==Quat();
+			return *reinterpret_cast<const Quat*>(_data._mem)==Quat();
 
 		} break;
 		case MATRIX3: {


### PR DESCRIPTION
Detected due to a compiler warning.